### PR TITLE
scenario voor in onderzoek 089999 die gemeld moet worden als onderzoek

### DIFF
--- a/features/raadpleeg-bewoning-met-periode/in-onderzoek.feature
+++ b/features/raadpleeg-bewoning-met-periode/in-onderzoek.feature
@@ -35,12 +35,13 @@ Rule: het in onderzoek zijn van de 'identificatiecode verblijfplaats' en/of 'dat
     | 000000024           | true        |
 
     Voorbeelden:
-    | aanduiding in onderzoek | type                                         |
-    | 080000                  | hele categorie verblijfplaats                |
-    | 081000                  | hele groep adreshouding                      |
-    | 081030                  | datum aanvang adreshouding                   |
-    | 081100                  | hele groep adres                             |
-    | 081180                  | identificatiecode verblijfplaats             |
+    | aanduiding in onderzoek | type                             |
+    | 080000                  | hele categorie verblijfplaats    |
+    | 081000                  | hele groep adreshouding          |
+    | 081030                  | datum aanvang adreshouding       |
+    | 081100                  | hele groep adres                 |
+    | 081180                  | identificatiecode verblijfplaats |
+    | 089999                  | vastgesteld geen bewoner meer    |
 
   Abstract Scenario: '<type>' van vorige verblijfplaats is in onderzoek
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens

--- a/features/raadpleeg-bewoning-met-periode/in-onderzoek.feature
+++ b/features/raadpleeg-bewoning-met-periode/in-onderzoek.feature
@@ -19,7 +19,7 @@ Rule: het in onderzoek zijn van de 'identificatiecode verblijfplaats' en/of 'dat
   Abstract Scenario: '<type>' is in onderzoek
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) |
-    | 0800                              | 20100818                           | <aanduiding in onderzoek>       | 20200401                       |
+    | 0800                              | 20100818                           | <aanduiding in onderzoek>       | 20220401                       |
     Als bewoning wordt gezocht met de volgende parameters
     | naam                             | waarde             |
     | type                             | BewoningMetPeriode |
@@ -46,10 +46,10 @@ Rule: het in onderzoek zijn van de 'identificatiecode verblijfplaats' en/of 'dat
   Abstract Scenario: '<type>' van vorige verblijfplaats is in onderzoek
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) |
-    | 0800                              | 20100818                           | <aanduiding in onderzoek>       | 20200401                       |
+    | 0800                              | 20100818                           | <aanduiding in onderzoek>       | 20220401                       |
     En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
     | datum aanvang adreshouding (10.30) |
-    | 20210803                           |
+    | 20220803                           |
     Als bewoning wordt gezocht met de volgende parameters
     | naam                             | waarde             |
     | type                             | BewoningMetPeriode |
@@ -71,6 +71,7 @@ Rule: het in onderzoek zijn van de 'identificatiecode verblijfplaats' en/of 'dat
     | 581030                  | datum aanvang adreshouding       |
     | 581100                  | hele groep adres                 |
     | 581180                  | identificatiecode verblijfplaats |
+    | 589999                  | vastgesteld geen bewoner meer    |
 
   Abstract Scenario: '<type>' is in onderzoek
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens

--- a/features/raadpleeg-bewoning-op-peildatum/in-onderzoek.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/in-onderzoek.feature
@@ -19,7 +19,7 @@ Rule: het in onderzoek zijn van de 'identificatiecode verblijfplaats' en/of 'dat
   Abstract Scenario: '<type>' is in onderzoek
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) |
-    | 0800                              | 20100818                           | <aanduiding in onderzoek>       | 20200401                       |
+    | 0800                              | 20100818                           | <aanduiding in onderzoek>       | 20210401                       |
     Als bewoning wordt gezocht met de volgende parameters
     | naam                             | waarde               |
     | type                             | BewoningMetPeildatum |
@@ -45,7 +45,7 @@ Rule: het in onderzoek zijn van de 'identificatiecode verblijfplaats' en/of 'dat
   Abstract Scenario: '<type>' van vorige verblijfplaats is in onderzoek
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) | aanduiding in onderzoek (83.10) | datum ingang onderzoek (83.20) |
-    | 0800                              | 20100818                           | <aanduiding in onderzoek>       | 20200401                       |
+    | 0800                              | 20100818                           | <aanduiding in onderzoek>       | 20210401                       |
     En de persoon is vervolgens ingeschreven op adres 'A2' met de volgende gegevens
     | gemeente van inschrijving (09.10) | datum aanvang adreshouding (10.30) |
     | 0800                              | 20210526                           |
@@ -69,6 +69,7 @@ Rule: het in onderzoek zijn van de 'identificatiecode verblijfplaats' en/of 'dat
     | 581030                  | datum aanvang adreshouding       |
     | 581100                  | hele groep adres                 |
     | 581180                  | identificatiecode verblijfplaats |
+    | 589999                  | vastgesteld geen bewoner meer    |
 
   Abstract Scenario: '<type>' is in onderzoek
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens

--- a/features/raadpleeg-bewoning-op-peildatum/in-onderzoek.feature
+++ b/features/raadpleeg-bewoning-op-peildatum/in-onderzoek.feature
@@ -40,6 +40,7 @@ Rule: het in onderzoek zijn van de 'identificatiecode verblijfplaats' en/of 'dat
     | 081030                  | datum aanvang adreshouding       |
     | 081100                  | hele groep adres                 |
     | 081180                  | identificatiecode verblijfplaats |
+    | 089999                  | vastgesteld geen bewoner meer    |
 
   Abstract Scenario: '<type>' van vorige verblijfplaats is in onderzoek
     Gegeven de persoon met burgerservicenummer '000000024' is ingeschreven op adres 'A1' met de volgende gegevens


### PR DESCRIPTION
aangezien PR #171 als low pro is vastgesteld en feature vastgesteld-verblijft-niet-op-adres als skip-verify staat wordt nu bij onderzoek 089999 helemaal geen onderzoek meer geleverd door de proxy. De gebruiker krijgt dan dus niks te horen dat er iets mis is met dit adres.

Zolang de onderzoek 089999 er niet uit filteren, zou er denk ik wel gewoon onderzoek voor deze situaties geleverd moeten worden. 