### PR TITLE
fix:verwijderen voorbeeld in BewoningenQuery

### DIFF
--- a/specificatie/openapi.yaml
+++ b/specificatie/openapi.yaml
@@ -72,11 +72,6 @@ components:
       properties:
         type:
           type: string
-      example:
-        type: 'BewoningMetPeriode'
-        datumVan: '2023-11-19'
-        datumTot: '2024-01-27'
-        adresseerbaarObjectIdentificatie: '0599010370005001'
 
     BewoningMetPeildatum:
       required:


### PR DESCRIPTION
Fixes #314

Voorbeeld bij BewoningenQuery verwijderd, zodat Redoc een correct voorbeeld voor de request body kan genereren bij elk type.